### PR TITLE
Queries can include periods without breaking the cache

### DIFF
--- a/addon/components/hyper-search.js
+++ b/addon/components/hyper-search.js
@@ -18,13 +18,25 @@ const {
  * Returns the key for the query in the cache. Only works in conjunction with
  * Ember.get.
  *
- * Replaces periods (.) with dashes (-)
  *
  * @public
  * @param {String} query
  * @return {String} nested key name
  */
 function keyForQuery(query) {
+  return `_cache.${safeKeyString(query)}`;
+}
+
+/**
+ * Ensure string does not contain characters that will cause Ember.get to break
+ *
+ * IE: Replaces periods (.) with dashes (-)
+ *
+ * @public
+ * @param {String} query
+ * @return {String} safe key name
+*/
+function safeKeyString(query) {
   return query.replace('.', '-');
 }
 
@@ -48,16 +60,16 @@ export default Component.extend({
   },
 
   cache(query, results) {
-    set(this, `_cache.${keyForQuery(query)}`, results);
+    set(this, keyForQuery(query), results);
     return resolve(results);
   },
 
   getCacheForQuery(query) {
-    return get(this, `_cache.${keyForQuery(query)}`);
+    return get(this, keyForQuery(query));
   },
 
   removeFromCache(query) {
-    delete this._cache[keyForQuery(query)];
+    delete this._cache[safeKeyString(query)];
     this.notifyPropertyChange('_cache');
   },
 

--- a/addon/components/hyper-search.js
+++ b/addon/components/hyper-search.js
@@ -18,12 +18,14 @@ const {
  * Returns the key for the query in the cache. Only works in conjunction with
  * Ember.get.
  *
+ * Replaces periods (.) with dashes (-)
+ *
  * @public
  * @param {String} query
  * @return {String} nested key name
  */
 function keyForQuery(query) {
-  return `_cache.${query}`;
+  return query.replace('.', '-');
 }
 
 export default Component.extend({
@@ -46,12 +48,16 @@ export default Component.extend({
   },
 
   cache(query, results) {
-    set(this, keyForQuery(query), results);
+    set(this, `_cache.${keyForQuery(query)}`, results);
     return resolve(results);
   },
 
+  getCacheForQuery(query) {
+    return get(this, `_cache.${keyForQuery(query)}`);
+  },
+
   removeFromCache(query) {
-    delete this._cache[query];
+    delete this._cache[keyForQuery(query)];
     this.notifyPropertyChange('_cache');
   },
 
@@ -70,7 +76,7 @@ export default Component.extend({
       return reject();
     }
 
-    let cachedValue = get(this, keyForQuery(query));
+    let cachedValue = this.getCacheForQuery(query);
 
     return isPresent(cachedValue) ? resolve(cachedValue) : this.requestAndCache(...arguments);
   },

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "ember-qunit": "0.4.17",
     "ember-qunit-notifications": "0.1.0",
     "ember-resolver": "~0.1.20",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.4.0",
     "qunit": "~1.20.0",
     "pretender": "^0.10.0",

--- a/tests/unit/components/hyper-search-test.js
+++ b/tests/unit/components/hyper-search-test.js
@@ -33,6 +33,18 @@ test('#requestAndCache caches queries and their results', function(assert) {
     });
 });
 
+test('#requestAndCache caches queries with periods', function(assert) {
+  const component = this.subject({ endpoint: '/' });
+  // no need to actually do an ajax request
+  sandbox.stub(component, 'request', resolve);
+
+  return component.requestAndCache('pizza@party.com')
+    .then((results) => {
+      assert.equal(results, 'pizza-party-com', 'should return results');
+      assert.equal(get(component, '_cache.pizza-party-com'), 'foo', 'should return and cache results');
+    });
+});
+
 test('#removeFromCache removes a result from the cache', function(assert) {
   const expectedResult = { poo: '💩' };
   const component = this.subject({ endpoint: '/' });
@@ -43,6 +55,20 @@ test('#removeFromCache removes a result from the cache', function(assert) {
       poo: '💩'
     });
     component.removeFromCache('foo');
+    assert.deepEqual(get(component, '_cache'), expectedResult, 'should remove the cached result');
+  });
+});
+
+test('#removeFromCache removes a result with period from cache', function(assert) {
+  const expectedResult = { poo: '💩' };
+  const component = this.subject({ endpoint: '/' });
+
+  run(() => {
+    component.set('_cache', {
+      'foo-zle': 'foo',
+      poo: '💩'
+    });
+    component.removeFromCache('foo.zle');
     assert.deepEqual(get(component, '_cache'), expectedResult, 'should remove the cached result');
   });
 });

--- a/tests/unit/components/hyper-search-test.js
+++ b/tests/unit/components/hyper-search-test.js
@@ -40,8 +40,8 @@ test('#requestAndCache caches queries with periods', function(assert) {
 
   return component.requestAndCache('pizza@party.com')
     .then((results) => {
-      assert.equal(results, 'pizza-party-com', 'should return results');
-      assert.equal(get(component, '_cache.pizza-party-com'), 'foo', 'should return and cache results');
+      assert.equal(results, 'pizza@party.com', 'should return results');
+      assert.equal(get(component, '_cache.pizza@party-com'), 'pizza@party.com', 'should return and cache results');
     });
 });
 


### PR DESCRIPTION
If you're using a hypersearch component to search for things that contain periods, like email addresses, as soon as you type the period things break. Since it's using the query itself as the key, Embers get/set gets all sorts of crankypants  This commit replaces periods in queries as dashes.

I duplicated some of the tests to account for this scenario. It feels a bit ham-fisted, but I was hesitant to refactor the keyForQuery method to make it easily testable on its own. 

Let me know if you have thoughts about how to do this better. 
