### PR TITLE
ember-one-way-input is now ember-one-way-controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
-    "ember-one-way-input": "^0.4.0"
+    "ember-one-way-controls": "^1.1.2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This just updates the dependency on `ember-one-way-input` to use `ember-one-way-controls` instead. 

The old version of `ember-one-way-input` had a dependency on an old version of `ember-cli-htmlbars` which was triggering the following warning in our application:

```
DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `ember-cli-htmlbars`
    at Function.Addon.lookup (/Users/bdmac/code/pyro/node_modules/ember-cli/lib/models/addon.js:1005:27)
```

Updating the dependency here allowed for only the newer `ember-cli-htmlbars` to be loaded which does not trigger the deprecation.